### PR TITLE
Update reused.rs

### DIFF
--- a/src/reused.rs
+++ b/src/reused.rs
@@ -87,7 +87,7 @@ where
     Authority: TryFrom<A>,
     <Authority as TryFrom<A>>::Error: Into<HttpError>,
 {
-    builder(client::https_default(), Scheme::HTTP, authority)
+    builder(client::https_default(), Scheme::HTTPS, authority)
 }
 
 /// Builder of [`ReusedService`], with [`client::nativetls_default()`].
@@ -104,7 +104,7 @@ where
     Authority: TryFrom<A>,
     <Authority as TryFrom<A>>::Error: Into<HttpError>,
 {
-    builder(client::nativetls_default(), Scheme::HTTP, authority)
+    builder(client::nativetls_default(), Scheme::HTTPS, authority)
 }
 
 /// Builder of [`ReusedService`], with [`client::rustls_default()`].
@@ -121,7 +121,7 @@ where
     Authority: TryFrom<A>,
     <Authority as TryFrom<A>>::Error: Into<HttpError>,
 {
-    builder(client::rustls_default(), Scheme::HTTP, authority)
+    builder(client::rustls_default(), Scheme::HTTPS, authority)
 }
 
 /// Builder of [`ReusedService`].


### PR DESCRIPTION
Fixed incorrect scheme for https builders. When using nativetls (the only one I tested with) because the scheme was `Scheme::HTTP` it sent requests to upstream in plain HTTP instead of as encrypted. This fixes the scheme for encrypted builders so they use an encrypted scheme. Unless I missed something in the documentation that otherwise flips the scheme...