### PR TITLE
Support Hyper > 1.0.0 and Axum > 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ include = ["src/", "LICENSE-*", "README.md"]
 
 [features]
 default = ["http1"]
-http1 = ["hyper/http1"]
-http2 = ["hyper/http2"]
+http1 = ["hyper/http1", "hyper-util/http1"]
+http2 = ["hyper/http2", "hyper-util/http2"]
 https = ["nativetls"]
 nativetls = ["hyper-tls"]
 rustls = ["rustls-webpki-roots"]
@@ -27,20 +27,23 @@ __rustls = ["hyper-rustls"]
 
 [dependencies]
 tower-service = "0.3"
-http = "0.2"
-hyper = { version = "0.14", features = ["client", "tcp"] }
+http = "1.0.0"
+http-body = "1.0.0"
+hyper = { version = "1.1.0", features = ["client"] }
 
-axum = { version = "0.6", features = [], optional = true }
+axum = { version = "0.7.3", features = [], optional = true }
 
-hyper-tls = { version = "0.5", optional = true }
-hyper-rustls = { version = "0.24", optional = true }
+hyper-tls = { version = "0.6.0", optional = true }
+hyper-rustls = { version = "0.24.2", optional = true }
 
 regex = "1.8"
-log = "0.4"
+log = "0.4.20"
+hyper-util =  { version = "0.1.2", features = ["client", "client-legacy", "tokio"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 mockito = "0.31"
+http-body-util = "0.1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,11 @@
 //! Includes helper functions to build [`Client`]s, and some re-exports from [`hyper::client`] or
 //! [`hyper_tls`].
+//!
+use hyper::body::Body as HttpBody;
+pub use hyper_util::client::legacy::{Builder, Client};
 
-use hyper::body::HttpBody;
-pub use hyper::client::{Builder, Client};
-
-use hyper::client::connect::Connect;
-pub use hyper::client::connect::HttpConnector;
+use hyper_util::client::legacy::connect::Connect;
+pub use hyper_util::client::legacy::connect::HttpConnector;
 
 #[cfg(feature = "https")]
 #[cfg_attr(docsrs, doc(cfg(feature = "https")))]
@@ -21,7 +21,7 @@ pub use hyper_tls::HttpsConnector as NativeTlsConnector;
 
 /// Default [`Builder`].
 pub fn builder() -> Builder {
-    Builder::default()
+    Builder::new(hyper_util::rt::TokioExecutor::new())
 }
 
 /// Same as [`Client::new()`], except for the `B` parameter.
@@ -30,7 +30,7 @@ where
     B: HttpBody + Send,
     B::Data: Send,
 {
-    Builder::default().build_http()
+    Builder::new(hyper_util::rt::TokioExecutor::new()).build_http()
 }
 
 /// Alias to [`nativetls_default()`].
@@ -110,5 +110,5 @@ where
     B: HttpBody + Send,
     B::Data: Send,
 {
-    Builder::default().build(conn)
+    Builder::new(hyper_util::rt::TokioExecutor::new()).build(conn)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use http::Error as HttpError;
-use hyper::Error as HyperError;
+use hyper_util::client::legacy::Error as HyperError;
 
 #[cfg(feature = "axum")]
 use axum::response::{IntoResponse, Response};

--- a/src/future.rs
+++ b/src/future.rs
@@ -5,8 +5,8 @@ use http::uri::{Authority, Scheme};
 use http::Error as HttpError;
 use http::{Request, Response};
 
-use hyper::body::{Body, HttpBody};
-use hyper::client::{connect::Connect, Client, ResponseFuture};
+use hyper::body::{Body as HttpBody, Incoming};
+use hyper_util::client::legacy::{connect::Connect, Client, ResponseFuture};
 
 use std::convert::Infallible;
 use std::future::Future;
@@ -29,7 +29,7 @@ impl RevProxyFuture {
     ) -> Self
     where
         C: Connect + Clone + Send + Sync + 'static,
-        B: HttpBody + Send + 'static,
+        B: HttpBody + Send + 'static + Unpin,
         B::Data: Send,
         B::Error: Into<BoxErr>,
         Pr: PathRewriter,
@@ -43,7 +43,7 @@ impl RevProxyFuture {
 }
 
 impl Future for RevProxyFuture {
-    type Output = Result<Result<Response<Body>, Error>, Infallible>;
+    type Output = Result<Result<Response<Incoming>, Error>, Infallible>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match &mut self.inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,9 @@ mod test_helper {
     use http::StatusCode;
     use http::{Request, Response};
 
-    use hyper::body::Body;
+    use hyper::body::Incoming;
+
+    use http_body_util::BodyExt;
 
     use tower_service::Service;
 
@@ -194,7 +196,7 @@ mod test_helper {
     ) where
         S: Service<
             Request<String>,
-            Response = Result<Response<Body>, Error>,
+            Response = Result<Response<Incoming>, Error>,
             Error = Infallible,
             Future = RevProxyFuture,
         >,
@@ -218,16 +220,16 @@ mod test_helper {
         assert!(res.is_ok());
         let res = res.unwrap();
         assert_eq!(res.status(), expected.0);
-        let res = hyper::body::to_bytes(res.into_body()).await;
+        let res = res.into_body().collect().await;
         assert!(res.is_ok());
-        assert_eq!(res.unwrap(), expected.1);
+        assert_eq!(res.unwrap().to_bytes(), expected.1);
     }
 
     pub async fn match_path<S>(svc: &mut S)
     where
         S: Service<
             Request<String>,
-            Response = Result<Response<Body>, Error>,
+            Response = Result<Response<Incoming>, Error>,
             Error = Infallible,
             Future = RevProxyFuture,
         >,
@@ -255,7 +257,7 @@ mod test_helper {
     where
         S: Service<
             Request<String>,
-            Response = Result<Response<Body>, Error>,
+            Response = Result<Response<Incoming>, Error>,
             Error = Infallible,
             Future = RevProxyFuture,
         >,
@@ -284,7 +286,7 @@ mod test_helper {
     where
         S: Service<
             Request<String>,
-            Response = Result<Response<Body>, Error>,
+            Response = Result<Response<Incoming>, Error>,
             Error = Infallible,
             Future = RevProxyFuture,
         >,
@@ -315,7 +317,7 @@ mod test_helper {
     where
         S: Service<
             Request<String>,
-            Response = Result<Response<Body>, Error>,
+            Response = Result<Response<Incoming>, Error>,
             Error = Infallible,
             Future = RevProxyFuture,
         >,


### PR DESCRIPTION
With version 1.0.0 the whole `Client` API has been removed from Hyper and put into the `hyper_util` crate as `hyper_util::client::legacy::*`.